### PR TITLE
Add barebones structure for restarting model state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [sources]
+ClimaCore = {rev = "main", url = "https://github.com/CliMA/ClimaCore.jl.git"}
 ClimaCoupler = {rev = "main", url = "https://github.com/CliMA/ClimaCoupler.jl"}
 
 [compat]


### PR DESCRIPTION
Added a function restart_sims! to restart a simulation (could be part of `Checkpointer.jl`?). As a simple test, restart_sims!() is called using the same callback frequency as checkpointing the model. That is, everytime the model state is written, it is re-read from the same file. This does not work at the moment since loading fields with a VF data layout is not supported by ClimaCore.