### PR TITLE
Refactor: Extract plotting from solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,72 +15,12 @@ To run the code:
 ```
 This solves the coupled heat equation on the time interval $t\in[0:3600] s$ with coupling time step $\Delta t_{cpl}=100 s$ and only one iteration per coupling time step.
 
-To get a plot of the convergence factor as a function of iteration, run:
+Simulation parameters (physical and numerical) can be changed by passing a dictionary `params` to `coupled_heat_equations()`, e.g.,
 ```julia
-coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
+coupled_heat_equations(iterations=10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000, :boundary_mapping => "mean"))
 ```
 
 If you want to use the parallel Schwarz iteration, run:
 ```julia
-coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
+coupled_heat_equations(iterations=10, parallel=true)
 ```
-
-To change to closest in time boundary mapping, run:
-```julia
-coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=true, boundary_mapping="cit", params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To combine two on eachother following convergence factors to see that the parallel and alternating Schwarz iteration are related, run:
-```julia
-coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=true, boundary_mapping="cit", combine_ρ_parallel=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-and for the alternating Schwarz:
-```julia
-coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=false, boundary_mapping="cit", params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To plot the convergence factor wrt a_i, run:
-```julia
-coupled_heat_equations(iterations=10, a_is=0:0.1:1, yscale=:log10, analytic_conv_fac=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To plot the convergence factor as a function of another variable, run for instance:
-```julia
-coupled_heat_equations(iterations=10, var_name="u_atm", analytic_conv_fac=true, yscale=:log10, params=Dict(:a_i=>0.1, :Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-For the same plot but for different values of a_i, run:
-```julia
-coupled_heat_equations(iterations=10, var_name="u_atm", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To get a plot of the cfl condition for the atmosphere, run:
-```julia
-coupled_heat_equations(plot_unstable_range=true, a_is=[0.1], params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To plot the same limit for three different a_i, run:
-```julia
-coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
-```
-
-To get the corresponding plot for the ocean, run:
-```julia
-coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000), compute_atm_conv_fac=false)
-```
-
-To verify that the convergence factor is a decreasing function of $\omega$ and $\nu$, run:
-```julia
-analytical_convergence_factor_dependence()
-```
-
- To plot the dependence of C_AO on L_AO, run:
- ```julia 
- plot_obukhov_C_dependencies("C_AO")
- ```
-
- To plot the dependence of C_AI on L_AI and a_i, run:
- ```julia
- plot_obukhov_C_dependencies("C_AI")
- ```

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=true, b
 
 To combine two on eachother following convergence factors to see that the parallel and alternating Schwarz iteration are related, run:
 ```julia
-coupled_heat_equations(iterations=10, print_conv_facs_iter=true, parallel=true, boundary_mapping="cit", combine_ρ_parallel=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
+coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=true, boundary_mapping="cit", combine_ρ_parallel=true, params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
 ```
 
 and for the alternating Schwarz:
 ```julia
-coupled_heat_equations(iterations=10, print_conv_facs_iter=true, parallel=false, boundary_mapping="cit", params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
+coupled_heat_equations(iterations=10, plot_conv_facs_iter=true, parallel=false, boundary_mapping="cit", params=Dict(:Δt_min=>10, :t_max=>1000, :Δt_cpl=>1000))
 ```
 
 To plot the convergence factor wrt a_i, run:

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ If you want to use the parallel Schwarz iteration, run:
 ```julia
 coupled_heat_equations(iterations=10, parallel=true)
 ```
+
+To reproduce the figures from Hanna Kjellson's MSc thesis, run, e.g.:
+```
+include("experiments/kjellson_thesis_plots.jl")
+figure71() # creates the plot corresponding to Fig. 7.1 in the thesis
+```

--- a/experiments/kjellson_thesis_plots.jl
+++ b/experiments/kjellson_thesis_plots.jl
@@ -51,3 +51,7 @@ end
 function figure77b()
     plot_unstable_range("oce", a_is=[0.1, 0.4, 0.7])
 end
+
+function ρ_dependence_ν_ω()
+    analytical_convergence_factor_dependence()
+end

--- a/experiments/kjellson_thesis_plots.jl
+++ b/experiments/kjellson_thesis_plots.jl
@@ -45,9 +45,9 @@ function figure76b()
 end
 
 function figure77a()
-    coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+    plot_unstable_range("atm", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure77b()
-    coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_atm_conv_fac=false)
+    plot_unstable_range("oce", a_is=[0.1, 0.4, 0.7])
 end

--- a/experiments/kjellson_thesis_plots.jl
+++ b/experiments/kjellson_thesis_plots.jl
@@ -1,0 +1,53 @@
+using clima_playground
+
+function figure71()
+    coupled_heat_equations(iterations=10, a_is=0:0.1:1, yscale=:log10, analytic_conv_fac=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+end
+
+function figure72a()
+    coupled_heat_equations(iterations=10, var_name="u_atm", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure72b()
+    coupled_heat_equations(iterations=10, var_name="u_oce", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure73a()
+    plot_obukhov_C_dependencies("C_AO")
+end
+
+function figure73b()
+    plot_obukhov_C_dependencies("C_AI")
+end
+
+function figure74a()
+    coupled_heat_equations(iterations=10, var_name="C_AO", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure74b()
+    coupled_heat_equations(iterations=10, var_name="C_AI", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure74c()
+    coupled_heat_equations(iterations=10, var_name="C_OI", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure75()
+    coupled_heat_equations(iterations=10, var_name="t_max", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure76a()
+    coupled_heat_equations(iterations=10, var_name="n_atm", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure76b()
+    coupled_heat_equations(iterations=10, var_name="n_oce", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+end
+
+function figure77a()
+    coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+end
+
+function figure77b()
+    coupled_heat_equations(plot_unstable_range=true, a_is=[0.1, 0.4, 0.7], params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_atm_conv_fac=false)
+end

--- a/experiments/kjellson_thesis_plots.jl
+++ b/experiments/kjellson_thesis_plots.jl
@@ -1,7 +1,7 @@
 using clima_playground
 
 function figure71()
-    coupled_heat_equations(iterations=10, a_is=0:0.1:1, yscale=:log10, analytic_conv_fac=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+    plot_ρ_over_a_i()
 end
 
 function figure72a()

--- a/experiments/kjellson_thesis_plots.jl
+++ b/experiments/kjellson_thesis_plots.jl
@@ -5,11 +5,11 @@ function figure71()
 end
 
 function figure72a()
-    coupled_heat_equations(iterations=10, var_name="u_atm", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "u_atm", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure72b()
-    coupled_heat_equations(iterations=10, var_name="u_oce", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "u_oce", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure73a()
@@ -21,27 +21,27 @@ function figure73b()
 end
 
 function figure74a()
-    coupled_heat_equations(iterations=10, var_name="C_AO", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "C_AO", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure74b()
-    coupled_heat_equations(iterations=10, var_name="C_AI", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "C_AI", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure74c()
-    coupled_heat_equations(iterations=10, var_name="C_OI", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "C_OI", a_is=[0.1, 0.4, 0.7])
 end
 
 function figure75()
-    coupled_heat_equations(iterations=10, var_name="t_max", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "t_max", a_is=[0.1, 0.4, 0.7], xscale=:log10)
 end
 
 function figure76a()
-    coupled_heat_equations(iterations=10, var_name="n_atm", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "n_atm", a_is=[0.1, 0.4, 0.7], xscale=:log10)
 end
 
 function figure76b()
-    coupled_heat_equations(iterations=10, var_name="n_oce", a_is=[0.1, 0.4, 0.7], analytic_conv_fac=true, yscale=:log10, xscale=:log10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000), compute_oce_conv_fac=false)
+    plot_ρ_over_var(10, "n_oce", a_is=[0.1, 0.4, 0.7], xscale=:log10)
 end
 
 function figure77a()

--- a/src/clima_playground.jl
+++ b/src/clima_playground.jl
@@ -7,6 +7,7 @@ export compute_ρ_analytical
 export define_realistic_vals
 export plot_ρ_over_k
 export plot_unstable_range
+export plot_ρ_over_a_i
 
 using LinearAlgebra
 using Plots

--- a/src/clima_playground.jl
+++ b/src/clima_playground.jl
@@ -6,6 +6,7 @@ export analytical_convergence_factor_dependence
 export compute_ρ_analytical
 export define_realistic_vals
 export plot_ρ_over_k
+export plot_unstable_range
 
 using LinearAlgebra
 using Plots

--- a/src/clima_playground.jl
+++ b/src/clima_playground.jl
@@ -5,6 +5,7 @@ export plot_obukhov_C_dependencies
 export analytical_convergence_factor_dependence
 export compute_ρ_analytical
 export define_realistic_vals
+export plot_ρ_over_k
 
 using LinearAlgebra
 using Plots

--- a/src/clima_playground.jl
+++ b/src/clima_playground.jl
@@ -8,6 +8,7 @@ export define_realistic_vals
 export plot_ρ_over_k
 export plot_unstable_range
 export plot_ρ_over_a_i
+export plot_ρ_over_var
 
 using LinearAlgebra
 using Plots

--- a/src/convergence_factors.jl
+++ b/src/convergence_factors.jl
@@ -70,7 +70,7 @@ function compute_ρ_numerical(
     physical_values;
     iterations=1,
 )
-    cs = get_coupled_sim(physical_values)
+    cs = get_coupled_sim(NamedTuple(physical_values))
     conv_fac_atm, conv_fac_oce = solve_coupler!(
         cs,
         iterations=iterations,
@@ -130,11 +130,11 @@ function get_conv_facs_one_variable(
 
     for (j, a_i) in enumerate(a_i_variable)
         physical_values[:a_i] = a_i
-        physical_values = update_physical_values(a_i, physical_values)
+        correct_for_a_i!(physical_values)
         for (k, var) in enumerate(vars)
             physical_values[Symbol(var_name)] = var
             if var_name == "a_i"
-                physical_values = update_physical_values(var, physical_values)
+                correct_for_a_i!(physical_values)
             elseif var_name == "h_atm"
                 physical_values[:n_atm] = Int((var - physical_values[:z_0numA]) / Δz_atm)
             elseif var_name == "h_oce"
@@ -151,7 +151,7 @@ function get_conv_facs_one_variable(
             for (k, var) in enumerate(variable2_range)
                 physical_values[Symbol(var_name)] = var
                 if var_name == "a_i"
-                    physical_values = update_physical_values(var, physical_values)
+                    correct_for_a_i!(physical_values)
                 elseif var_name == "t_max"
                     physical_values[:w_min] = π / var
                 end

--- a/src/convergence_factors.jl
+++ b/src/convergence_factors.jl
@@ -69,21 +69,13 @@ Computes the numerical convergence factor based on the parameters in physical_va
 function compute_ρ_numerical(
     physical_values;
     iterations=1,
-    return_conv_facs=true,
-    plot_conv_facs=false,
-    print_conv_facs=false,
 )
     cs = get_coupled_sim(physical_values)
-    out = solve_coupler!(
+    conv_fac_atm, conv_fac_oce = solve_coupler!(
         cs,
         iterations=iterations,
-        print_conv=print_conv_facs,
-        plot_conv=plot_conv_facs,
-        return_conv=return_conv_facs,
     )
-    if return_conv_facs
-        return out[1], out[2]
-    end
+    return conv_fac_atm, conv_fac_oce
 end
 
 """

--- a/src/convergence_factors.jl
+++ b/src/convergence_factors.jl
@@ -186,7 +186,7 @@ function stability_check(physical_values, n_zs, n_ts, var1_name, var2_name)
             physical_values[Symbol(var1_name)] = n_z
             physical_values[Symbol(var2_name)] = n_t
 
-            cs = get_coupled_sim(physical_values)
+            cs = get_coupled_sim(NamedTuple(physical_values))
 
             starting_temp_atm = parent(cs.model_sims.atmos_sim.Y_init)
             starting_temp_oce = parent(cs.model_sims.ocean_sim.Y_init)

--- a/src/coupled_simulation.jl
+++ b/src/coupled_simulation.jl
@@ -13,10 +13,6 @@ Creates a CoupledSimulation.
 
 -`physical_values::Dict`: Can be defined using `define_realistic_vals()`. 
 
-**Optional Keyword Arguments:**
-
--`boundary_mapping::String`: Either `"mean"` or `"cit"` (closest in time), default: `"mean"`.
-
 """
 function get_coupled_sim(parameters)
     context = CC.ClimaComms.context()

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -306,8 +306,10 @@ function solve_coupler!(
 
         if iterations > 1
             conv_fac_atm, conv_fac_oce = compute_ρ(atmos_vals_list, ocean_vals_list, stopped_at_nan_atm, stopped_at_nan_oce)
-            return conv_fac_atm, conv_fac_oce
+        else
+            conv_fac_atm, conv_fac_oce = nothing, nothing
         end
+        return conv_fac_atm, conv_fac_oce
     end
 end
 

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -89,17 +89,6 @@ Runs the CoupledSimulation.
 
 -`iterations::Int`: Number of iterations before the Schwarz iteration is terminated, default: `1`.
 -`parallel::Boolean`: Whether to run the parallel or alternating Schwarz iteration, default: `false`.
--`print_conv::Boolean`: Whether to print the convergence factor or not, default: `false`.
--`plot_conv::Boolean`: Whether to plot the convergence factor or not, default: `false`.
--`return_conv::Boolean`: Whether to return the convergence factor or not, default: `false`.
--`analytic_conv_fac_value::Float64`: The analytical convergence factor. If sent in,
-    it is plotted and printed with the numerical convergence factor, default: `nothing`.
--`combine_ρ_parallel::Boolean`: Whether to combine two on eachother following convergence factor values
-    for the parallel Schwarz iteration, default: `false`.
--`compute_atm_conv_fac::Boolean`: Whether to consider the atmospheric convergence factor or only the oceanic, default: `true`.
--`compute_oce_conv_fac::Boolean`: Whether to consider the oceanic convergence factor, default: `true`.
--`legend::Symbol`: Legend placement for plotting, default: `:right`.
-
 """
 function solve_coupler!(
     cs::Interfacer.CoupledSimulation;
@@ -387,7 +376,6 @@ Setup for running the coupled simulation and running it.
 -`parallel::Boolean`: Whether to run the parallel or alternating Schwarz iteration, default: `false`.
 -`boundary_mapping::String`: Determines if mean or closest in time boundary mapping is used, default: `"mean"`.
 -`params::Dict`: Physical parameters and time stepping parameters, default: `false`, default: `Dict{Symbol,Int}()`.
--`print_conv_facs_iter::Boolean`: Whether to print the convergence factor or not, default: `false`.
 -`plot_conv_facs_iter::Boolean`: Whether to plot the convergence factor or not, default: `false`.
 -`analytic_conv_fac::Boolean`: Whether to compute and plot or print the analytical convergence factor, default: `false`.
 -`compute_atm_conv_fac::Boolean`: Whether to consider the atmospheric convergence factor, default: `true`.
@@ -412,7 +400,6 @@ function coupled_heat_equations(;
     parallel=false,
     boundary_mapping="mean",
     params=Dict{Symbol,Int}(),
-    print_conv_facs_iter=false,
     plot_conv_facs_iter=false,
     analytic_conv_fac=false,
     compute_atm_conv_fac=true,

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -376,12 +376,9 @@ Setup for running the coupled simulation and running it.
 -`parallel::Boolean`: Whether to run the parallel or alternating Schwarz iteration, default: `false`.
 -`boundary_mapping::String`: Determines if mean or closest in time boundary mapping is used, default: `"mean"`.
 -`params::Dict`: Physical parameters and time stepping parameters, default: `false`, default: `Dict{Symbol,Int}()`.
--`plot_conv_facs_iter::Boolean`: Whether to plot the convergence factor or not, default: `false`.
 -`analytic_conv_fac::Boolean`: Whether to compute and plot or print the analytical convergence factor, default: `false`.
 -`compute_atm_conv_fac::Boolean`: Whether to consider the atmospheric convergence factor, default: `true`.
 -`compute_oce_conv_fac::Boolean`: Whether to consider the oceanic convergence factor, default: `true`.
--`combine_ρ_parallel::Boolean`: Whether to combine two on eachother following convergence factor values
-    for the parallel Schwarz iteration, default: `false`.
 -`plot_unstable_range::Boolean`: Whether to plot the unstable region (cfl condition), default: `false`.
 -`a_is::Array`: If not empty, the convergence factor is plotted as a function of `a_is`, default: `[]`.
 -`var_name::String`: If not nothing, the convergence factor is plotted wrt the variable.
@@ -400,11 +397,9 @@ function coupled_heat_equations(;
     parallel=false,
     boundary_mapping="mean",
     params=Dict{Symbol,Int}(),
-    plot_conv_facs_iter=false,
     analytic_conv_fac=false,
     compute_atm_conv_fac=true,
     compute_oce_conv_fac=true,
-    combine_ρ_parallel=false,
     plot_unstable_range=false,
     a_is=[],
     var_name=nothing,
@@ -422,7 +417,6 @@ function coupled_heat_equations(;
     physical_values[:boundary_mapping] = boundary_mapping
 
     if !(
-        plot_conv_facs_iter ||
         plot_unstable_range ||
         !isempty(a_is) ||
         !isnothing(var_name)

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -506,38 +506,6 @@ function coupled_heat_equations(;
                 compute_oce_conv_fac=compute_oce_conv_fac,
             )
         end
-
-    elseif !isempty(a_is)
-        # Plot convergence factor wrt a_i
-        conv_facs_atm, conv_facs_oce, param_analytic, conv_facs_analytic =
-            get_conv_facs_one_variable(
-                physical_values,
-                a_is,
-                "a_i",
-                iterations=iterations,
-                analytic=analytic_conv_fac,
-                log_scale=(xscale == :log10),
-            )
-        xticks = !isnothing(xticks) ? xticks : a_is
-        plot_wrt_a_i_and_one_param(
-            conv_facs_oce,
-            conv_facs_atm,
-            [physical_values[:a_i]],
-            a_is,
-            L"$a^I$",
-            conv_facs_analytic=conv_facs_analytic,
-            param_analytic=param_analytic,
-            xticks=xticks,
-            yticks=yticks,
-            xscale=xscale,
-            yscale=yscale,
-            colors=[:black],
-            linestyles=[:solid],
-            text_scaling=text_scaling,
-            legend=legend,
-            compute_atm_conv_fac=compute_atm_conv_fac,
-            compute_oce_conv_fac=compute_oce_conv_fac,
-        )
     end
 end;
 

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -395,9 +395,3 @@ function coupled_heat_equations(;
     )
     return cs, conv_fac_atm, conv_fac_oce
 end;
-
-
-
-
-
-

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -303,14 +303,12 @@ function solve_coupler!(
             # values, if this is not run to empty it.
             reset_time!(cs, t)
         end
-
         if iterations > 1
             conv_fac_atm, conv_fac_oce = compute_ρ(atmos_vals_list, ocean_vals_list, stopped_at_nan_atm, stopped_at_nan_oce)
-        else
-            conv_fac_atm, conv_fac_oce = nothing, nothing
+            return conv_fac_atm, conv_fac_oce
         end
-        return conv_fac_atm, conv_fac_oce
     end
+    return nothing, nothing
 end
 
 function compute_ρ(atmos_vals_list, ocean_vals_list, stopped_at_nan_atm, stopped_at_nan_oce)

--- a/src/heat_equations.jl
+++ b/src/heat_equations.jl
@@ -419,6 +419,8 @@ function coupled_heat_equations(;
 )
     physical_values = define_realistic_vals()
     merge!(physical_values, params)
+    correct_for_a_i!(physical_values)
+    compute_C_AO!(physical_values)
     physical_values[:boundary_mapping] = boundary_mapping
 
     if !(

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -605,3 +605,45 @@ function plot_unstable_range(component; a_is=[])
     end
     display(current())
 end
+
+
+function plot_ρ_over_a_i(iterations=10, analytic_conv_fac=true)
+    xscale = :identity
+    yscale = :log10
+    legend = :right
+    yticks = :auto
+    a_is = 0:0.1:1
+    text_scaling = (1, 5)
+    physical_values = define_realistic_vals()
+    params = Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000)
+    merge!(physical_values, params)
+    conv_facs_atm, conv_facs_oce, param_analytic, conv_facs_analytic =
+        get_conv_facs_one_variable(
+            physical_values,
+            a_is,
+            "a_i",
+            iterations=iterations,
+            analytic=analytic_conv_fac,
+            log_scale=(xscale == :log10),
+        )
+    xticks = a_is
+    plot_wrt_a_i_and_one_param(
+        conv_facs_oce,
+        conv_facs_atm,
+        [physical_values[:a_i]],
+        a_is,
+        L"$a^I$",
+        conv_facs_analytic=conv_facs_analytic,
+        param_analytic=param_analytic,
+        xticks=xticks,
+        yticks=yticks,
+        xscale=xscale,
+        yscale=yscale,
+        colors=[:black],
+        linestyles=[:solid],
+        text_scaling=text_scaling,
+        legend=legend,
+        compute_atm_conv_fac=true,
+        compute_oce_conv_fac=false,
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,33 +2,33 @@ import Test: @test
 import Statistics
 using clima_playground
 
-cs = coupled_heat_equations(iterations=10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0199795729795)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.9999761867679)
 
-cs = coupled_heat_equations(iterations=10, parallel=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, parallel=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0199795729795)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.9999761867679)
 
-cs = coupled_heat_equations(iterations=10, boundary_mapping="cit", params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, boundary_mapping="cit", params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0199795729795)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.9999761867679)
 
-cs = coupled_heat_equations(iterations=10, boundary_mapping="cit", parallel=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, boundary_mapping="cit", parallel=true, params=Dict(:Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0199795729795)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.9999761867679)
 
-cs = coupled_heat_equations(iterations=10, params=Dict(:a_i => 0.5, :Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, params=Dict(:a_i => 0.5, :Δt_min => 10, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0157868000668)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.9816379915888)
 @test isapprox(Statistics.mean(cs.model_sims.ice_sim.integrator.sol.u[end]), 270.0)
 
-cs = coupled_heat_equations(iterations=10, params=Dict(:a_i => 1.0, :Δt_min => 10, :T_ice_ini => 250.0, :t_max => 1000, :Δt_cpl => 1000))
+cs, _ = coupled_heat_equations(iterations=10, params=Dict(:a_i => 1.0, :Δt_min => 10, :T_ice_ini => 250.0, :t_max => 1000, :Δt_cpl => 1000))
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 266.9138392636568)
 @test isapprox(Statistics.mean(cs.model_sims.ocean_sim.integrator.sol.u[end]), 270.5827944417085)
 @test isapprox(Statistics.mean(cs.model_sims.ice_sim.integrator.sol.u[end]), 250.0)
 
-cs = coupled_heat_equations()
+cs, _ = coupled_heat_equations()
 @test isapprox(Statistics.mean(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.021160864323)
 @test isapprox(maximum(cs.model_sims.atmos_sim.integrator.sol.u[end]), 270.98203813664367)
 @test isapprox(minimum(cs.model_sims.atmos_sim.integrator.sol.u[end]), 267.0)


### PR DESCRIPTION
First big round of refactoring: Moved all plotting functionality outside the solver calls (i.e., `coupled_heat_equations()`, `solve_coupler!()`).

Added a new script `experiments/kjellson_thesis_plots.jl`, which contains functions for creating all the plots from the thesis. Regression tests work as expected and the plots look as before.