### PR TITLE
Use relative instead of absolute time inside solvers

### DIFF
--- a/src/components/atmosphere.jl
+++ b/src/components/atmosphere.jl
@@ -14,26 +14,19 @@ end
 Interfacer.name(::HeatEquationAtmos) = "HeatEquationAtmos"
 
 function heat_atm_rhs!(dT, T, cache, t)
-    if cache.boundary_mapping == "mean"
-        F_sfc = (
-            cache.a_I *
-            cache.C_AI *
-            (T[1] - parent(cache.T_Is)[1]) +
-            (1 - cache.a_I) *
-            cache.C_AO *
-            (T[1] - parent(cache.T_O)[1])
-        )
-    else
+    index = 1
+    if cache.boundary_mapping == "cit"
         index = argmin(abs.(parent(CC.Fields.coordinate_field(cache.T_O)) .- t))
-        F_sfc = (
-            cache.a_I *
-            cache.C_AI *
-            (T[1] - parent(cache.T_Is)[index]) +
-            (1 - cache.a_I) *
-            cache.C_AO *
-            (T[1] - parent(cache.T_O)[index])
-        )
     end
+    F_sfc = (
+        cache.a_I *
+        cache.C_AI *
+        (T[1] - parent(cache.T_Is)[index]) +
+        (1 - cache.a_I) *
+        cache.C_AO *
+        (T[1] - parent(cache.T_O)[index])
+    )
+
     # set boundary conditions
     C3 = CC.Geometry.WVector
     # note: F_sfc is converted to a Cartesian vector in direction 3 (vertical)

--- a/src/components/ocean.jl
+++ b/src/components/ocean.jl
@@ -14,26 +14,18 @@ end
 Interfacer.name(::HeatEquationOcean) = "HeatEquationOcean"
 
 function heat_oce_rhs!(dT, T, cache, t)
-    if cache.boundary_mapping == "mean"
-        F_sfc = (
-            cache.a_I *
-            cache.C_IO *
-            (cache.T_Ib - T[end]) +
-            (1 - cache.a_I) *
-            cache.C_AO *
-            (parent(cache.T_A)[1] - T[end])
-        )
-    else
+    index = 1
+    if cache.boundary_mapping == "cit"
         index = argmin(abs.(parent(CC.Fields.coordinate_field(cache.T_A)) .- t))
-        F_sfc = (
-            cache.a_I *
-            cache.C_IO *
-            (cache.T_Ib - T[end]) +
-            (1 - cache.a_I) *
-            cache.C_AO *
-            (parent(cache.T_A)[index] - T[end])
-        )
     end
+    F_sfc = (
+        cache.a_I *
+        cache.C_IO *
+        (cache.T_Ib - T[end]) +
+        (1 - cache.a_I) *
+        cache.C_AO *
+        (parent(cache.T_A)[index] - T[end])
+    )
 
     ## set boundary conditions
     C3 = CC.Geometry.WVector

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -34,8 +34,8 @@ Base.@kwdef mutable struct SimulationParameters
     T_O_ini = 271.0
     T_I_ini = 270.0
     h_I_ini = 1.0
-    t_max = 3600.0
-    Δt_cpl = 100.0
+    t_max::Float64 = 3600.0
+    Δt_cpl::Float64 = 100.0
     Δt_min = 1.0
     n_t_A = 50
     n_t_O = 1


### PR DESCRIPTION
The solvers now integrate from t0 to t0 + Δt_cpl,
 instead of knowing internally about t_max (total duration of simulation)
Main effect: CIT boundary mapping now works even when t_max > Δt_cpl (i.e., fixes #42). Also, the checkpoint files are now overwritten in each new coupling window, leading to much less files generated during a simulation. While I was at it, I refactored the atm/oce RHS functions to reduce code duplication.